### PR TITLE
Fixed error if user doesn't pass in a callback.

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -54,9 +54,11 @@ module.exports = function(apiKey) {
 
             request.on('response', function (response) {
                 response.setEncoding('utf8');
-                response.on('data', function (chunk) {
-                    callback(null, chunk);
-                });
+                if (typeof callback !== 'undefined') {
+                    response.on('data', function (chunk) {
+                        callback(null, chunk);
+                    });
+                }
             });
             request.end(JSON.stringify(payload));
         },


### PR DESCRIPTION
I should be able to _not_ pass in a callback to postageapp.sendMessage, but the lib currently crashes if I don't.
