### PR TITLE
Removed calls to deprecated node API.

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -5,14 +5,17 @@ var postageVersion = '1.1.0';
 module.exports = function(apiKey) {
     return {
         sendMessage: function (options, callback) {
-            var api = http.createClient(80, 'api.postageapp.com');
-
-            var request = api.request('POST', '/v.1.0/send_message.json',
-                {
+            var request = http.request({
+                'port': 80,
+                'host': 'api.postageapp.com',
+                'method': 'POST',
+                'path': '/v.1.0/send_message.json',
+                'headers': {
                     'host': 'api.postageapp.com',
                     'content-type': 'application/json',
                     'user-agent': 'PostageApp Node.JS ' + postageVersion + ' (Node.JS ' + process.version + ')'
-                });
+                }
+            });
 
             var recipients = options.recipients;
 
@@ -62,14 +65,17 @@ module.exports = function(apiKey) {
         },
 
         accountInfo: function () {
-            var api = http.createClient(80, 'api.postageapp.com');
-
-            var request = api.request('POST', '/v.1.0/get_account_info.json',
-                {
+            var request = http.request({
+                'port': 80,
+                'host': 'api.postageapp.com',
+                'method': 'POST',
+                'path': '/v.1.0/get_account_info.json',
+                'headers': {
                     'host': 'api.postageapp.com',
                     'content-type': 'application/json',
                     'user-agent': 'PostageApp Node.JS ' + postageVersion + ' (Node.JS ' + process.version + ')'
-                });
+                }
+            });
 
             var payload = {
                 api_key: apiKey
@@ -86,13 +92,16 @@ module.exports = function(apiKey) {
         },
         
         messageStatus: function (options) {
-            var api = http.createClient(80, 'api.postageapp.com');
-
-            var request = api.request('POST', '/v.1.0/message_status.json', 
-            {
+             var request = http.request({
+                'port': 80,
                 'host': 'api.postageapp.com',
-                  'content-type': 'application/json',
-                  'user-agent': 'PostageApp Node.JS ' + postageVersion + ' (Node.JS ' + process.version + ')'
+                'method': 'POST',
+                'path': '/v.1.0/message_status.json',
+                'headers': {
+                    'host': 'api.postageapp.com',
+                    'content-type': 'application/json',
+                    'user-agent': 'PostageApp Node.JS ' + postageVersion + ' (Node.JS ' + process.version + ')'
+                }
             });
 
             var desiredUID = options.desiredUID;


### PR DESCRIPTION
Fixed warning message from Node: "http.createClient is deprecated. Use `http.request` instead."
