### PR TITLE
Fixed UID generation to conform with API spec.

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -1,4 +1,6 @@
-var http = require('http');
+var http = require('http'),
+    crypto = require('crypto'),
+    shasum = crypto.createHash('sha1');
 
 var postageVersion = '1.1.0';
 
@@ -27,10 +29,10 @@ module.exports = function(apiKey) {
 
             /*
              Creates a string of numbers to be used for the UID, which has to be a unique identifier in order
-             to prevent duplicate sending through PostageApp.
+             to prevent duplicate sending through PostageApp. We also need to make sure this is a string rather
+             than just an integer - so a hash of the timestamp and a couple arguments will do nicely.
              */
-            var date = new Date;
-            var epochDate = date.getTime();
+            shasum.update((new Date).getTime().toString() + content.toString() + subject.toString());
 
             /*
              Payload is the aggregated data that will be passed to the API server including all of the parameters
@@ -38,7 +40,7 @@ module.exports = function(apiKey) {
              */
             var payload = {
                 api_key: apiKey,
-                uid: epochDate,
+                uid: shasum.digest('hex'),
                 arguments: {
                     recipients: recipients,
                     headers: {


### PR DESCRIPTION
The library was previously generating UIDs as integers - which the API would reject. Changing the generated UID to a hash of the timestamp, content and subject line seems to work fine.
