### PR TITLE
Use message hash to generate uid instead

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -1,4 +1,5 @@
 var http = require('http');
+var crypto = require('crypto');
 
 var postageVersion = '1.1.0';
 
@@ -32,8 +33,8 @@ module.exports = function(apiKey) {
              Creates a string of numbers to be used for the UID, which has to be a unique identifier in order
              to prevent duplicate sending through PostageApp.
              */
-            var date = new Date;
-            var epochDate = date.getTime();
+            var str = JSON.stringify(options);
+            var hash = crypto.createHash('sha1').update(str).digest('hex');
 
             /*
              Payload is the aggregated data that will be passed to the API server including all of the parameters
@@ -41,7 +42,7 @@ module.exports = function(apiKey) {
              */
             var payload = {
                 api_key: apiKey,
-                uid: epochDate,
+                uid: hash,
                 arguments: {
                     recipients: recipients,
                     headers: {


### PR DESCRIPTION
When I'm firing off several send requests in one go (from a simple for-loop), some of these requests will end up with the same timestamp as uids, which then gets rejected by the api as dupes.

The hash of the request itself works better as a uid.
