### PR TITLE
Ability to get/set apiKey via exported method call

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -7,6 +7,14 @@ module.exports = function(apiKey) {
     return {
         version: function() { return postageVersion; },
 
+        getApiKey: function(apiKey) {
+            return apiKey;
+        },
+
+        setApiKey: function(newKey) {
+            apiKey = newKey;
+        },
+
         sendMessage: function (options, success, error) {
             var recipients = options.recipients;
 

--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -7,7 +7,7 @@ module.exports = function(apiKey) {
     return {
         version: function() { return postageVersion; },
 
-        getApiKey: function(apiKey) {
+        getApiKey: function() {
             return apiKey;
         },
 


### PR DESCRIPTION
My app is long-running, so it would be best if a server-restart were not required if I wanted to change the `apiKey`.

This change is backwards compatible, it just adds two new methods, `getApiKey` and `setApiKey`