### PR TITLE
Support recipient_override argument in sendMessage

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -9,6 +9,7 @@ module.exports = function(apiKey) {
 
         sendMessage: function (options, success, error) {
             var recipients = options.recipients;
+            var recipientOverride = options.recipient_override;
 
             var subject = options.subject;
             var from = options.from;
@@ -39,6 +40,7 @@ module.exports = function(apiKey) {
                 uid: hash,
                 arguments: {
                     recipients: recipients,
+                    recipient_override: recipientOverride,
                     headers: {
                         subject: subject,
                         from: from

--- a/test/postageapp.js
+++ b/test/postageapp.js
@@ -42,5 +42,20 @@ describe('postageapp', function () {
                 done();
             });
         });
+
+        it('should support recipient override', function(done) {
+          postageapp.sendMessage({
+            content: 'recipient override test',
+            recipients: 'test@null.postageapp.com',
+            recipient_override: 'test2@null.postageapp.com'
+          }, function (throwaway, r) {
+            assert.equal('ok', r.response.status);
+            done();
+          }, function (err) {
+            console.log(err);
+            assert(false, 'should not have received an error');
+            done();
+          });
+        });
     });
 });


### PR DESCRIPTION
Fixes #14.  Adds support for `recipient_override` argument in `postageapp.sendMessage()`.

Example usage:
```javascript
postageapp.sendMessage(
    {recipient_override: 'override@example.com', ...}, 
    successFn, 
    errorFn
);
```