### PR TITLE
Reject send on invalid response body.

### DIFF
--- a/lib/postageapp.js
+++ b/lib/postageapp.js
@@ -70,7 +70,12 @@ class PostageApp {
         });
 
         response.on('end', () => {
-          var reply = JSON.parse(buffer);
+          try {
+            var reply = JSON.parse(buffer);
+          } catch (err) {
+            reject(err);
+            return;
+          }
 
           switch (response.statusCode) {
             case 200:


### PR DESCRIPTION
Certain situations currently cause the Postageapp API to respond with an HTML error page rather than a JSON response body. This caused the Postageapp send() method to throw a SyntaxError attempting to parse the response body rather than rejecting the Promise.

If merged, this PR will catch the error thrown by JSON.parse() and reject with the caught error.